### PR TITLE
Clarify behavior of Non-Finishing Contexts

### DIFF
--- a/docs/source/generating/actions.rst
+++ b/docs/source/generating/actions.rst
@@ -119,7 +119,7 @@ The ``context()`` method returns the ``Action``:
          # do some stuff...
          action.finish()
 
-Don't log within an action's context after it has been finished:
+You shouldn't log within an action's context after it has been finished:
 
 .. code-block:: python
 
@@ -129,7 +129,7 @@ Don't log within an action's context after it has been finished:
          Message.log(message_type=u"ok")
          # finish the action:
          action.finish()
-         # BUG: this message is being added to a finished action!
+         # Don't do this! This message is being added to a finished action!
          Message.log(message_type=u"late")
 
 As an alternative to ``with``, you can also explicitly run a function within the action context:

--- a/docs/source/generating/actions.rst
+++ b/docs/source/generating/actions.rst
@@ -119,19 +119,20 @@ The ``context()`` method returns the ``Action``:
          # do some stuff...
          action.finish()
 
-Keep in mind that code within the context block that is run after the action is finished will still be in that action's context:
+Don't log within an action's context after it has been finished:
 
 .. code-block:: python
 
      from eliot import start_action, Message
 
      with start_action(action_type=u"message_late").context() as action:
-         # do some stuff...
+         Message.log(message_type=u"ok")
+         # finish the action:
          action.finish()
-         # but this message still belongs to that action!
-         Message.log(status=u"late")
+         # BUG: this message is being added to a finished action!
+         Message.log(message_type=u"late")
 
-You can also explicitly run a function within the action context:
+As an alternative to ``with``, you can also explicitly run a function within the action context:
 
 .. code-block:: python
 

--- a/docs/source/generating/actions.rst
+++ b/docs/source/generating/actions.rst
@@ -92,7 +92,6 @@ You can do so with ``Action.context()``.
 You can explicitly finish an action by calling ``eliot.Action.finish``.
 If called with an exception it indicates the action finished unsuccessfully.
 If called with no arguments it indicates that the action finished successfully.
-Keep in mind that code within the context block that is run after the action is finished will still be in that action's context.
 
 .. code-block:: python
 
@@ -119,6 +118,18 @@ The ``context()`` method returns the ``Action``:
      with start_action(action_type=u"your_type").context() as action:
          # do some stuff...
          action.finish()
+
+Keep in mind that code within the context block that is run after the action is finished will still be in that action's context:
+
+.. code-block:: python
+
+     from eliot import start_action, Message
+
+     with start_action(action_type=u"message_late").context() as action:
+         # do some stuff...
+         action.finish()
+         # but this message still belongs to that action!
+         Message.log(status=u"late")
 
 You can also explicitly run a function within the action context:
 


### PR DESCRIPTION
Adds an explicit example of "code within the context block that is run after the action is finished will still be in that action's context."